### PR TITLE
Don't include LGPL docs in the docs if both embed-lgpl-docs and purge…

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,10 @@ fn main() {
     manage_docs();
 }
 
-#[cfg(any(feature = "embed-lgpl-docs", feature = "purge-lgpl-docs"))]
+#[cfg(all(
+    any(feature = "embed-lgpl-docs", feature = "purge-lgpl-docs"),
+    not(all(feature = "embed-lgpl-docs", feature = "purge-lgpl-docs"))
+))]
 fn manage_docs() {
     extern crate lgpl_docs;
     const PATH: &'static str = "src";
@@ -13,5 +16,8 @@ fn manage_docs() {
     }
 }
 
-#[cfg(not(any(feature = "embed-lgpl-docs", feature = "purge-lgpl-docs")))]
+#[cfg(any(
+    all(feature = "embed-lgpl-docs", feature = "purge-lgpl-docs"),
+    not(any(feature = "embed-lgpl-docs", feature = "purge-lgpl-docs"))
+))]
 fn manage_docs() {}


### PR DESCRIPTION
…-lgpl-docs features are selected

This makes usage of RLS/rust-analyzer on the repository much faster and
less annoying as the docs don't have to be included and removed on every
change.

----
CC @GuillaumeGomez @EPashkin 